### PR TITLE
Remove KBDapps

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -5,10 +5,6 @@
            fetch=".."
            review="review.lineageos.org" />
 
-  <remote name="kbdmods"
-          fetch="https://github.com/koboldo81"
-	  revision="master" />
-	
   <remote name="busybox"
 	  fetch="https://github.com/PureNexusProject"
 	  revision="android-7.1" />
@@ -37,8 +33,6 @@
   <project path="packages/apps/Settings" name="koboldo81/android_packages_apps_Settings" groups="pdk-fs" />
   <project path="frameworks/base" name="koboldo81/android_frameworks_base" groups="pdk-cw-fs,pdk-fs" />
 
-  <project path="packages/apps/KBDapps" name="android_packages_apps_KBDapps" remote="kbdmods" />
-  <project path="packages/apps/Viper4Android" name="android_packages_apps_viper4android" remote="kbdmods" />
   <project path="packages/apps/Superuser" name="Superuser" remote="superuser" />
   <project path="packages/apps/Superuser/Widgets" name="Widgets" remote="superuser" />
   <project path="external/busybox" name="android_external_busybox" remote="busybox" />


### PR DESCRIPTION
Due to the compilation problems, KBDapps are removed. This include Kernel Adiutor and ViPER4Android. This one is included in Magisk, which I personally got working after compiling independently.
If I can add it to the build...